### PR TITLE
Load TGM only if needed

### DIFF
--- a/pmpro-bbpress.php
+++ b/pmpro-bbpress.php
@@ -11,7 +11,9 @@
 /**
  * Include the TGM_Plugin_Activation class.
  */
-require_once dirname( __FILE__ ) . '/class-tgm-plugin-activation.php';
+if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
+	require_once dirname( __FILE__ ) . '/class-tgm-plugin-activation.php';
+}
 
 /**
  * Register the required plugins for this theme.


### PR DESCRIPTION
There is confusion between the TGM supplied with the plugin and the current version of TGM from the makers of that product. This results in an error "Fatal error: Call to protected TGM_Plugin_Activation...". By loading your version of TGM only when there isn't already one loaded, one or the other is used, and the confusion and error go away.