### PR TITLE
ENHANCEMENT: Save the referring page to $_SESSION

### DIFF
--- a/pmpro-bbpress.php
+++ b/pmpro-bbpress.php
@@ -47,7 +47,10 @@ function pmprobbp_check_forum() {
 	if( ! bbp_is_forum_archive() && ! empty( $forum_id ) && pmpro_bbp_is_forum() ) {
 		// The current user does not have access to this forum, re-direct them away
 		if( ! pmpro_has_membership_access( $forum_id ) ) {
-			wp_redirect(add_query_arg('noaccess', 1, get_post_type_archive_link( 'forum' )));
+			
+			// save to session in case we want to redirect later on
+			$_SESSION['pmpro_bbp_redirected_from'] = $_SERVER['REQUEST_URI'];
+			wp_redirect( add_query_arg( 'noaccess', 1, get_post_type_archive_link( 'forum' ) ) );
 			exit;
 		}
 	}


### PR DESCRIPTION
Since we use redirect to deny access to a forum, we clobber the link the user used to try and get there. This makes it impossible to redirect the user back to their desired page after they've logged in.
