### PR TITLE
Updating inline help text to use the WordPress standard 'description' class on a paragraph tag.

### DIFF
--- a/includes/options-membership-levels.php
+++ b/includes/options-membership-levels.php
@@ -68,14 +68,14 @@ function pmprobb_pmpro_membership_level_after_other_settings()
 					}
 				?>
 			</select>
-			<small>Leave as "Default Behavior" if you don't need to change roles by membership level.</small>
+			<p class="description">Leave as "Default Behavior" if you don't need to change roles by membership level.</p>
 		</td>
 	</tr>
 	<tr>
 		<th scope="row" valign="top"><label for="forum_color"><?php _e('Background Color', 'pmpro');?></label></th>
 		<td>			
 			<input type="text" id="forum_color" name="forum_color" value="<?php echo esc_attr($forum_color);?>" />
-			<small>You can also add custom styles for .pmpro-level-<?php echo $level_id;?> via your CSS files.</small>			
+			<p class="description">You can also add custom styles for <code>.pmpro-level-<?php echo $level_id;?></code> via your CSS files.</p>
 		</td>
 	</tr>	
 </tbody>

--- a/includes/options.php
+++ b/includes/options.php
@@ -85,7 +85,7 @@ function pmprobb_option_error_message() {
 		$error_message = "";
 	?>
 	<input id='pmprobb_option_error_message' name='pmprobb_option_error_message' size='40' type='text' value='<?php echo esc_attr($error_message);?>' />
-	<small>This message is shown when users attempt to view a forum or thread they don't have access to.</small>
+	<p class="description">This message is shown when users attempt to view a forum or thread they don't have access to.</p>
 	<?php
 }
 


### PR DESCRIPTION
Inline hints were using the "small" tag. I have been updating all inline hints / help text to use the WordPress standard in the admin which is the following:

`<p class="description"> .... </p>`

The help text in this Add On is not yet localized.