### PR TITLE
BUG FIX: Fix pre_get_posts to run on frontend only.

### DIFF
--- a/pmpro-bbpress.php
+++ b/pmpro-bbpress.php
@@ -60,7 +60,7 @@ add_action('init', 'pmprobb_init', 50);
  * @since 1.7
  */
 function pmprobb_filter_forum_search_results( $query ) {
-	if ( apply_filters( 'pmprobb_filter_topic_queries', true ) && function_exists('bbp_is_search_results') && bbp_is_search_results() ) {
+	if ( ! is_admin() && apply_filters( 'pmprobb_filter_topic_queries', true ) && function_exists('bbp_is_search_results') && bbp_is_search_results() ) {
 		add_filter( 'pre_get_posts', 'pmprobb_pre_get_posts' );
 	}
 	return $query;


### PR DESCRIPTION
BUG FIX: Fixes an issue where pre_get_posts was running on backend and interfering with other plugins like WPForms.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

