### PR TITLE
BUG FIX: Issue of running pre_get_posts on non-WP Query

### DIFF
--- a/pmpro-bbpress.php
+++ b/pmpro-bbpress.php
@@ -60,6 +60,12 @@ add_action('init', 'pmprobb_init', 50);
  * @since 1.7
  */
 function pmprobb_filter_forum_search_results( $query ) {
+	
+	// Make sure that the query we want to filter has posts.
+	if ( ! $query->have_posts() ) {
+		return $query;
+	}
+
 	if ( ! is_admin() && apply_filters( 'pmprobb_filter_topic_queries', true ) && function_exists('bbp_is_search_results') && bbp_is_search_results() ) {
 		add_filter( 'pre_get_posts', 'pmprobb_pre_get_posts' );
 	}
@@ -180,6 +186,11 @@ function pmprobb_pre_get_posts($query) {
 		
   	// Make sure pmpro and bbpress are active.
 	if ( ! defined( 'PMPRO_VERSION' ) || ! class_exists( 'bbPress' ) ) {
+		return $query;
+	}
+
+	// Make sure that the query we want to filter has posts.
+	if ( ! $query->have_posts() ) {
 		return $query;
 	}
 


### PR DESCRIPTION
BUG FIX: Fixed an issue where pre_get_posts was trying to run checks on non WP Query's. Fixes an issue for Formidable registration forms.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
