### PR TITLE
Updating headings for a11y

### DIFF
--- a/includes/options-membership-levels.php
+++ b/includes/options-membership-levels.php
@@ -36,7 +36,7 @@ function pmprobb_pmpro_membership_level_after_other_settings()
 		$forum_color = '';
 	
 ?>
-<h3 class="topborder">bbPress Settings</h3>
+<h2 class="topborder">bbPress Settings</h2>
 <table>
 <tbody class="form-table">
 	<tr>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.